### PR TITLE
reqwest-middleware update & some conveniences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 debug/
 target/
 
+# Direnv config file and symlinks
+.envrc
+.direnv/
+
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 
 [dependencies]
 names = "0.14.0"
-reqwest = { version = "0.12.7", features = ["native-tls", "json"] }
+reqwest = { version = "0.12.7", features = ["rustls-tls", "json"] }
 reqwest-middleware = { version = "0.4.2", features = ["http2", "json"] }
 reqwest-tracing = "0.5.3"
 secrecy = "0.10.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,23 +12,22 @@ license = "MIT"
 
 [dependencies]
 names = "0.14.0"
-once_cell = "1.19.0"
-pretty_assertions = "1.4.1"
 reqwest = { version = "0.12.7", features = ["native-tls", "json"] }
-reqwest-middleware = { version = "0.3.3", features = ["http2", "json"] }
+reqwest-middleware = { version = "0.4.2", features = ["http2", "json"] }
 reqwest-tracing = "0.5.3"
 secrecy = "0.10.2"
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.128"
 thiserror = "1.0.64"
 tracing = "0.1.40"
-typetag = "0.2.18"
 uuid = { version = "1.10.0", features = ["v4", "serde"] }
 
 [dev-dependencies]
-rstest = "0.22.0"
-async-std = { version = "1.13", features = ["attributes", "tokio1"] }
-tracing-subscriber = { version = "0.3.18", default-features = false, features = ["std", "fmt", "ansi"] }
 anyhow = "1.0.89"
-wiremock = "0.5"
+async-std = { version = "1.13", features = ["attributes", "tokio1"] }
+once_cell = "1.19.0"
+pretty_assertions = "1.4.1"
+rstest = "0.22.0"
 tokio = { version = "1.40.0", features = ["full"] }
+tracing-subscriber = { version = "0.3.18", default-features = false, features = ["std", "fmt", "ansi"] }
+wiremock = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["email", "mailjet"]
 license = "MIT"
 
 [dependencies]
-names = "0.14.0"
+names = { version = "0.14.0", default_features = false }
 reqwest = { version = "0.12.7", features = ["rustls-tls", "json"] }
 reqwest-middleware = { version = "0.4.2", features = ["http2", "json"] }
 reqwest-tracing = "0.5.3"

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ If you plan to contribute to this crate, or you simple aim to run all the integr
 
 ```bash
 # This is what they call API KEY
-export MAILJET_API_USER=<hash>
-# This is what they call SECRET KEY
 export MAILJET_API_KEY=<hash>
+# This is what they call SECRET KEY
+export MAILJET_SECRET_KEY=<hash>
 # This address must be registered in your Mailjet account
 export MAILJET_FROM_EMAIL=<email address>
 ```

--- a/examples/simple_send_v3.rs
+++ b/examples/simple_send_v3.rs
@@ -2,7 +2,7 @@
 //!
 //! # Description
 //!
-//! This example builds a new client using two environment variables: **MAILJET_API_USER** and **MAILJET_API_KEY**.
+//! This example builds a new client using two environment variables: **MAILJET_API_KEY** and **MAILJET_SECRET_KEY**.
 //! These two variables must be defined in order to retrieve the credentials to use the external API.
 //!
 //! Then a simple client is build using the builder object ([mailjet_client::MailjetClientBuilder]), and an object
@@ -21,10 +21,10 @@ async fn main() -> Result<(), ClientError> {
     // Read the API user and key hashes from an environment variable and store them using Secrecy
     // to avoid data leaks.
     let api_user = SecretString::from(
-        env::var("MAILJET_API_USER").expect("Missing MAILJET_API_USER env variable"),
+        env::var("MAILJET_API_KEY").expect("Missing MAILJET_API_KEY env variable"),
     );
     let api_key = SecretString::from(
-        env::var("MAILJET_API_KEY").expect("Missing MAILJET_API_KEY env variable"),
+        env::var("MAILJET_SECRET_KEY").expect("Missing MAILJET_SECRET_KEY env variable"),
     );
 
     let mclient = MailjetClientBuilder::new(api_user, api_key)

--- a/src/mailjet_client.rs
+++ b/src/mailjet_client.rs
@@ -112,7 +112,6 @@ impl MailjetClient {
 
         let http_client = reqwest::ClientBuilder::new()
             .user_agent(user_agent)
-            .use_native_tls()
             .https_only(force_https.unwrap_or(true))
             .build()
             .map_err(|_| ClientError::HTTPClient)?;

--- a/tests/api/helper.rs
+++ b/tests/api/helper.rs
@@ -50,9 +50,9 @@ impl TestApp {
         Lazy::force(&TRACING);
 
         let api_user =
-            std::env::var("MAILJET_API_USER").expect("Missing MAILJET_API_USER env variable");
-        let api_key =
             std::env::var("MAILJET_API_KEY").expect("Missing MAILJET_API_KEY env variable");
+        let api_key =
+            std::env::var("MAILJET_SECRET_KEY").expect("Missing MAILJET_SECRET_KEY env variable");
 
         let email_address = match std::env::var("MAILJET_EMAIL") {
             Ok(email) => email,


### PR DESCRIPTION
All contained in commit message.
- update reqwest-middleware
- move a couple dev-only dependencies to dev-dependencies so they don't get included in regular library release
- remove `typetag` entirely, as it's unused
- added direnv-related things to .gitignore just because I use .direnv with Rust repos to provide env vars/auto-activate Nix flakes, so if you don't want this one I can remove and resubmit

Thanks for the neat crate!